### PR TITLE
Fixed Uncaught Invariant Violation in React v15.0.2

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -55,7 +55,7 @@ export default class Rater extends Component {
     let { index, rating } = getRatingFromDOMEvent(e, this.props)
       , lastRating = Number(this.state.lastRating)
       , callback = this.props.onRate
-    if (rating < 0 || this.refs[`star-${index}`].props.isDisabled) {
+    if (rating < 0 || e.target.className==='is-disabled') {
       return
     }
     this.setState({
@@ -77,8 +77,7 @@ export default class Rater extends Component {
         isActive: (!this.state.isRating && i < rating) ? true: false,
         willBeActive: (this.state.isRating && i < rating)? true: false,
         isDisabled: (i < limit) ? false: true,
-        key: `star-${i}`,
-        ref: `star-${i}`
+        key: `star-${i}`
       }
       if (children.length) {
         return React.cloneElement(children[i % children.length], starProps)


### PR DESCRIPTION
After I updated React to v15.0.2 it gives the following error:

Uncaught Invariant Violation: addComponentAsRefTo(...): Only a ReactOwner can have refs. You might be adding a ref to a component that was not created inside a component's `render` method, or you have multiple copies of React loaded (details:https://fb.me/react-refs-must-have-owner).