### PR TITLE
Change star's <a> tags with <div> tags

### DIFF
--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -9,7 +9,7 @@ describe('Interactive rater: <Rater total={5} rating={2} />', () => {
   const rater = mount(<Rater total={5} rating={2} />)
   it('renders 5 stars(2 active)', () => {
     expect(rater.find('.react-rater').length).toEqual(1)
-    expect(rater.find('a').length).toEqual(5)
+    expect(rater.find('div').length).toEqual(5)
     expect(rater.find('.is-active').length).toEqual(2)
   })
   it('renders 3 active stars when rate 3', () => {

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -9,7 +9,7 @@ describe('Interactive rater: <Rater total={5} rating={2} />', () => {
   const rater = mount(<Rater total={5} rating={2} />)
   it('renders 5 stars(2 active)', () => {
     expect(rater.find('.react-rater').length).toEqual(1)
-    expect(rater.find('div').length).toEqual(5)
+    expect(rater.find('div.star').length).toEqual(5)
     expect(rater.find('.is-active').length).toEqual(2)
   })
   it('renders 3 active stars when rate 3', () => {

--- a/src/react-rater.scss
+++ b/src/react-rater.scss
@@ -8,7 +8,7 @@ $react-rater-active: #000 !default;
   > * {
     display: inline-block;
   }
-  a {
+  .star {
     cursor: pointer;
     color: $react-rater-link;
     position: relative;

--- a/src/star.js
+++ b/src/star.js
@@ -13,7 +13,7 @@ export default class Star extends Component {
       .filter(prop => this.props[prop])
       .map(prop => nameMap[prop])
       .join(' ')
-    return <div className={className}>★</div>
+    return <div className={"star" + className}>★</div>
   }
 }
 

--- a/src/star.js
+++ b/src/star.js
@@ -13,7 +13,7 @@ export default class Star extends Component {
       .filter(prop => this.props[prop])
       .map(prop => nameMap[prop])
       .join(' ')
-    return <div className={"star" + className}>★</div>
+    return <div className={"star " + className}>★</div>
   }
 }
 

--- a/src/star.js
+++ b/src/star.js
@@ -13,7 +13,7 @@ export default class Star extends Component {
       .filter(prop => this.props[prop])
       .map(prop => nameMap[prop])
       .join(' ')
-    return <a className={className}>★</a>
+    return <div className={className}>★</div>
   }
 }
 


### PR DESCRIPTION
I find many usecases of using the 'Rater' component in a clickable element (in a card wrapped in a link for example). When doing this I get the error message "Warning: validateDOMNesting(…): 'a' cannot appear as a descendant of 'a'" as two a elements are nested. I found that replacing the 'a' with a 'div doesn't affect the behaviour of the 'Rater'. I think it could also be a 'span' instead of the 'div'... Up to you